### PR TITLE
Fixed bug leaving erroneous gaps in line.

### DIFF
--- a/Pod/Classes/LVSmoothLineView.m
+++ b/Pod/Classes/LVSmoothLineView.m
@@ -187,7 +187,7 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
     
     // update points: previousPrevious -> mid1 -> previous -> mid2 -> current
     self.previousPreviousPoint = self.previousPoint;
-    self.previousPoint = [touch previousLocationInView:self];
+    self.previousPoint = self.currentPoint;
     self.currentPoint = [touch locationInView:self];
     
     CGPoint mid1 = LVMiddlePoint(self.previousPoint, self.previousPreviousPoint);


### PR DESCRIPTION
Drawing slowly or drawing fine details with the Apple Pencil can result in gaps in the line.

The line should continue from the previous drawn point, not the gesture's previous point, as those diverge after skipping points.
