### PR TITLE
Enable force touch support

### DIFF
--- a/Pod/Classes/ENDBrush.m
+++ b/Pod/Classes/ENDBrush.m
@@ -34,4 +34,17 @@
     return newBrush;
 }
 
+- (BOOL)isEqual:(id)object
+{
+    if (![object isKindOfClass:[ENDBrush class]]) {
+        return NO;
+    }
+    
+    ENDBrush *other = object;
+    
+    return fabs(other.lineWidth - self.lineWidth) < 0.01 &&
+            [other.color isEqual:self.color] &&
+            [other.shadow isEqual:self.shadow];
+}
+
 @end

--- a/Pod/Classes/ENDBrushShadow.m
+++ b/Pod/Classes/ENDBrushShadow.m
@@ -23,5 +23,18 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)object
+{
+    if (![object isKindOfClass:[ENDBrushShadow class]]) {
+        return NO;
+    }
+    
+    ENDBrushShadow *other = object;
+    
+    
+    return fabs(other.blur - self.blur) < 0.01 &&
+            [other.color isEqual:self.color] &&
+            CGSizeEqualToSize(other.offset, self.offset);
+}
 
 @end

--- a/Pod/Classes/ENDDrawFillWithColorOperation.m
+++ b/Pod/Classes/ENDDrawFillWithColorOperation.m
@@ -15,6 +15,7 @@
 @end
 
 @implementation ENDDrawFillWithColorOperation
+@synthesize sequenceID;
 
 - (void)drawInContext:(CGContextRef)context inRect:(CGRect)rect
 {

--- a/Pod/Classes/ENDDrawOperation.h
+++ b/Pod/Classes/ENDDrawOperation.h
@@ -12,7 +12,8 @@
 
 @protocol ENDDrawOperation <NSObject>
 
-@property (nonatomic, readonly) CGRect drawRect;
+@property (nonatomic)           NSUInteger  sequenceID;
+@property (nonatomic, readonly) CGRect      drawRect;
 
 /// @param context  The drawing context
 /// @param rect     The draw rect

--- a/Pod/Classes/ENDDrawPathOperation.m
+++ b/Pod/Classes/ENDDrawPathOperation.m
@@ -20,6 +20,7 @@
 @end
 
 @implementation ENDDrawPathOperation
+@synthesize sequenceID;
 
 - (instancetype)init
 {

--- a/Pod/Classes/ENDDrawSession.h
+++ b/Pod/Classes/ENDDrawSession.h
@@ -19,6 +19,7 @@
 @property (nonatomic, copy, readonly) NSArray *operations;
 
 - (id <ENDDrawOperation>)beginOperation:(Class)operationClass;
+- (id <ENDDrawOperation>)beginOperation:(Class)operationClass inSequence:(BOOL)inSequence;
 - (void)endOperation;
 
 - (BOOL)canRemoveLastOperation;

--- a/Pod/Classes/LVSmoothLineView.m
+++ b/Pod/Classes/LVSmoothLineView.m
@@ -143,10 +143,7 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
         return;
     }
     
-    if (recognizer.state == UIGestureRecognizerStateBegan) {
-        [self drawOperationBegan:touches];
-    }
-    else if (recognizer.state == UIGestureRecognizerStateChanged) {
+    if (recognizer.state == UIGestureRecognizerStateBegan || recognizer.state == UIGestureRecognizerStateChanged) {
         [self drawOperationMoved:touches];
     }
     else if (recognizer.state == UIGestureRecognizerStateEnded) {
@@ -154,24 +151,34 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
     }
 }
 
-- (void)drawOperationBegan:(NSSet *)touches
-{
-    UITouch *touch = [touches anyObject];
-    
-    self.pathOperation = [self.session beginOperation:[ENDDrawPathOperation class]];
-    self.pathOperation.brush = [self.brush copy];
-    
-    // initializes our point records to current location
-    self.previousPoint = [touch previousLocationInView:self];
-    self.previousPreviousPoint = [touch previousLocationInView:self];
-    self.currentPoint = [touch locationInView:self];
-    
-    [self drawOperationMoved:touches];
-}
-
 - (void)drawOperationMoved:(NSSet *)touches
 {
     UITouch *touch = [touches anyObject];
+    
+    ENDBrush *proposedBrush = nil;
+    
+    if ([touch respondsToSelector:@selector(force)] && fabs([touch force] - 1.0f) > 0.01) {
+        proposedBrush = [self.brush copy];
+        proposedBrush.lineWidth = self.brush.lineWidth * ([touch force] / [touch maximumPossibleForce]) * 4.0f;
+    }
+    
+    if (self.pathOperation == nil) {
+        self.pathOperation = [self.session beginOperation:[ENDDrawPathOperation class] inSequence:NO];
+        self.pathOperation.brush = proposedBrush;
+        
+        // initializes our point records to current location
+        self.previousPoint = [touch previousLocationInView:self];
+        self.previousPreviousPoint = [touch previousLocationInView:self];
+        self.currentPoint = [touch locationInView:self];
+    }
+    else {
+        if (proposedBrush != nil && ![self.brush isEqual:proposedBrush]) {
+            [self drawOperationEnded:touches];
+            
+            self.pathOperation = [self.session beginOperation:[ENDDrawPathOperation class] inSequence:YES];
+            self.pathOperation.brush = proposedBrush;
+        }
+    }
     
     CGPoint point = [touch locationInView:self];
     
@@ -214,6 +221,7 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
 - (void)drawOperationEnded:(NSSet *)touches
 {
     [self.session endOperation];
+    self.pathOperation = nil;
 }
 
 - (void)longPressRecognized:(UILongPressGestureRecognizer *)recognizer
@@ -266,7 +274,7 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
     if (! color) {
         return;
     }
-    ENDDrawFillWithColorOperation *fillOperation = [self.session beginOperation:[ENDDrawFillWithColorOperation class]];
+    ENDDrawFillWithColorOperation *fillOperation = [self.session beginOperation:[ENDDrawFillWithColorOperation class] inSequence:NO];
     fillOperation.color = color;
     fillOperation.fillRect = self.bounds;
     

--- a/Pod/Classes/LVSmoothLineView.m
+++ b/Pod/Classes/LVSmoothLineView.m
@@ -161,6 +161,9 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
         proposedBrush = [self.brush copy];
         proposedBrush.lineWidth = self.brush.lineWidth * ([touch force] / [touch maximumPossibleForce]) * 4.0f;
     }
+    else {
+        proposedBrush = [self.brush copy];
+    }
     
     if (self.pathOperation == nil) {
         self.pathOperation = [self.session beginOperation:[ENDDrawPathOperation class] inSequence:NO];

--- a/Pod/Classes/LVSmoothLineView.m
+++ b/Pod/Classes/LVSmoothLineView.m
@@ -157,7 +157,7 @@ static CGPoint LVMiddlePoint(CGPoint p1, CGPoint p2) {
     
     ENDBrush *proposedBrush = nil;
     
-    if ([touch respondsToSelector:@selector(force)] && fabs([touch force] - 1.0f) > 0.01) {
+    if ([touch respondsToSelector:@selector(force)] && fabs([touch force] - 1.0f) > 0.01 && [touch maximumPossibleForce] != 0) {
         proposedBrush = [self.brush copy];
         proposedBrush.lineWidth = self.brush.lineWidth * ([touch force] / [touch maximumPossibleForce]) * 4.0f;
     }


### PR DESCRIPTION
- The size of the brush multiplier is selected by amount of force applied on the screen 
- To support correct undo-ing of variable width curves the `sequenceID` is introduced
- Undo/repo operations are working with batches of operations marked with the same `sequenceID`
- Implemented `isEqual:` on brush and brush shadow
